### PR TITLE
0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 A change log for the change log parser
 
+## Unreleased
+
+### Fixed
+
+- Fixed issue where the description returned the first release if no description was given
+- Better support for multi line descriptions.
+- Fixed issue where the parser crashed if a release had no date (for example and `unreleased` section)
+
 ## 0.7.0 - 2015-11-25
 
 * Updated the following dependencies to their latest versions: `league/commonmark:0.12.0`, `symfony/dom-crawler:2.7.7`, `symfony/css-selector:2.7.7`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 A change log for the change log parser
 
-## Unreleased
+## 0.7.1 - 2015-12-13
 
 ### Fixed
 

--- a/spec/Changelog/ParserSpec.php
+++ b/spec/Changelog/ParserSpec.php
@@ -22,6 +22,22 @@ class ParserSpec extends ObjectBehavior
 		$this->getDescription()->shouldReturn('A general description of your changelog');
 	}
 
+	function it_can_retrieve_multi_line_description()
+	{
+		$this->beConstructedWith(file_get_contents('spec/mocks/multi_line_description.md'));
+
+		$this->getDescription()->shouldReturn('A general description of your changelog
+
+on multiple lines');
+	}
+
+	function it_can_retrieve_no_description_if_not_available()
+	{
+		$this->beConstructedWith(file_get_contents('spec/mocks/no_description.md'));
+
+		$this->getDescription()->shouldReturn(null);
+	}
+
 	function it_can_retrieve_releases()
 	{
 		$this->getReleases()->shouldReturn([

--- a/spec/Changelog/ParserSpec.php
+++ b/spec/Changelog/ParserSpec.php
@@ -90,6 +90,60 @@ on multiple lines');
 		]);
     }
 
+	function it_can_retrieve_unreleased_changes()
+	{
+		$this->beConstructedWith(file_get_contents('spec/mocks/unreleased.md'));
+
+		$this->getReleases()->shouldReturn([
+				[
+						'name' => 'Unreleased',
+						'date' => null,
+						'changes' => [
+								'added' => [
+										'Addition 1',
+										'Addition 2',
+								],
+								'changed' => [
+										'Change 1',
+										'Change 2',
+								],
+								'removed' => [
+										'Removal 1',
+										'Removal 2',
+								]
+						]
+				],
+				[
+						'name' => '0.0.3',
+						'date' => '2014-08-09',
+						'changes' => [
+								'added' => [
+										'Addition 3',
+										'Addition 4',
+								],
+						]
+				],
+				[
+						'name' => '0.0.2',
+						'date' => '2014-07-10',
+						'changes' => [
+								'changed' => [
+										'Change 3',
+								],
+						]
+				],
+				[
+						'name' => '0.0.1',
+						'date' => '2014-05-31',
+						'changes' => [
+								'removed' => [
+										'Removal 3',
+								]
+						]
+				]
+		]);
+	}
+
 	function it_can_retrieve_a_single_list_of_changes()
 	{
 		$this->beConstructedWith(file_get_contents('spec/mocks/pull_request.md'));

--- a/spec/mocks/multi_line_description.md
+++ b/spec/mocks/multi_line_description.md
@@ -1,0 +1,33 @@
+# Change Log
+A general description of your changelog
+
+on multiple lines
+
+## 0.0.4 - 2014-08-09
+### Added
+- Addition 1
+- Addition 2
+
+### Changed
+- Change 1
+- Change 2
+
+### Removed
+- Removal 1
+- Removal 2
+
+## 0.0.3 - 2014-08-09
+
+### Added
+- Addition 3
+- Addition 4
+
+## 0.0.2 - 2014-07-10
+
+### Changed
+- Change 3
+
+## 0.0.1 - 2014-05-31
+
+### Removed
+- Removal 3

--- a/spec/mocks/no_description.md
+++ b/spec/mocks/no_description.md
@@ -1,0 +1,30 @@
+# Change Log
+
+## 0.0.4 - 2014-08-09
+### Added
+- Addition 1
+- Addition 2
+
+### Changed
+- Change 1
+- Change 2
+
+### Removed
+- Removal 1
+- Removal 2
+
+## 0.0.3 - 2014-08-09
+
+### Added
+- Addition 3
+- Addition 4
+
+## 0.0.2 - 2014-07-10
+
+### Changed
+- Change 3
+
+## 0.0.1 - 2014-05-31
+
+### Removed
+- Removal 3

--- a/spec/mocks/unreleased.md
+++ b/spec/mocks/unreleased.md
@@ -1,0 +1,31 @@
+# Change Log
+
+## Unreleased
+
+### Added
+- Addition 1
+- Addition 2
+
+### Changed
+- Change 1
+- Change 2
+
+### Removed
+- Removal 1
+- Removal 2
+
+## 0.0.3 - 2014-08-09
+
+### Added
+- Addition 3
+- Addition 4
+
+## 0.0.2 - 2014-07-10
+
+### Changed
+- Change 3
+
+## 0.0.1 - 2014-05-31
+
+### Removed
+- Removal 3

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3,64 +3,65 @@
 namespace Changelog;
 
 use Changelog\Retrievers\ChangesRetriever;
+use Changelog\Retrievers\DescriptionRetriever;
 use Changelog\Retrievers\ReleasesRetriever;
 use League\CommonMark\CommonMarkConverter;
 use Symfony\Component\DomCrawler\Crawler;
 
 class Parser
 {
-	/**
-	 * @var array
-	 */
-	protected $sections = ['added', 'changed', 'removed', 'fixed', 'security', 'deprecated'];
+    /**
+     * @var array
+     */
+    protected $sections = ['added', 'changed', 'removed', 'fixed', 'security', 'deprecated'];
 
-	/**
-	 * @var Crawler
-	 */
-	protected $content;
+    /**
+     * @var Crawler
+     */
+    protected $content;
 
-	/**
-	 * @param $content
-	 */
-	public function __construct($content)
-	{
-		$this->setContent($content);
-	}
+    /**
+     * @param $content
+     */
+    public function __construct($content)
+    {
+        $this->setContent($content);
+    }
 
-	/**
-	 * Retrieve all the releases from the change log
-	 *
-	 * @return array
-	 */
-	public function getReleases()
-	{
-		return (new ReleasesRetriever($this->content->filter('h2')))->retrieve();
-	}
+    /**
+     * Retrieve all the releases from the change log
+     *
+     * @return array
+     */
+    public function getReleases()
+    {
+        return (new ReleasesRetriever($this->content->filter('h2')))->retrieve();
+    }
 
-	/**
-	 * @return array|void
-	 */
-	public function getChanges()
-	{
-		return (new ChangesRetriever($this->content->filter('h3')))->retrieve();
-	}
+    /**
+     * @return array|void
+     */
+    public function getChanges()
+    {
+        return (new ChangesRetriever($this->content->filter('h3')))->retrieve();
+    }
 
-	/**
-	 * Set the content to parse
-	 *
-	 * @param $value
-	 */
-	public function setContent($value)
-	{
-		$converter = new CommonMarkConverter;
-		$this->content = new Crawler($converter->convertToHtml($value));
-	}
+    /**
+     * Set the content to parse
+     *
+     * @param $value
+     */
+    public function setContent($value)
+    {
+        $converter = new CommonMarkConverter;
+        $this->content = new Crawler($converter->convertToHtml($value));
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getDescription()
-	{
-		return $this->content->filter('h1')->nextAll()->first()->html();
-	}
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return (new DescriptionRetriever($this->content->filter('h1 ~ p')))->retrieve();
+    }
 }

--- a/src/Retrievers/DescriptionRetriever.php
+++ b/src/Retrievers/DescriptionRetriever.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Changelog\Retrievers;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class DescriptionRetriever extends AbstractRetriever
+{
+    /**
+     * @return null|string
+     */
+    public function retrieve()
+    {
+        $items = parent::retrieve();
+
+        if (!$items) {
+            return null;
+        }
+
+        return implode(PHP_EOL.PHP_EOL, $items);
+    }
+
+    /**
+     * @param Crawler $node
+     *
+     * @return string
+     */
+    protected function parse(Crawler $node)
+    {
+        return $node->text();
+    }
+}

--- a/src/Retrievers/ReleasesRetriever.php
+++ b/src/Retrievers/ReleasesRetriever.php
@@ -23,7 +23,7 @@ class ReleasesRetriever extends AbstractRetriever
 
 		return [
 			'name'    => $title[0],
-			'date'    => $title[1],
+			'date'    => isset($title[1]) ? $title[1] : null,
 			'changes' => $changes,
 		];
 	}


### PR DESCRIPTION
### Fixed

- Fixed issue where the description returned the first release if no description was given
- Better support for multi line descriptions.
- Fixed issue where the parser crashed if a release had no date (for example and `unreleased` section)