### PR TITLE
Fix nested bullet points

### DIFF
--- a/spec/Changelog/ParserSpec.php
+++ b/spec/Changelog/ParserSpec.php
@@ -190,4 +190,15 @@ on multiple lines');
 		$this->beConstructedWith(file_get_contents('spec/mocks/header_with_forgotten_text.md'));
 		$this->getChanges()->shouldReturn([]);
 	}
+
+	function it_can_handle_nested_bullet_points()
+	{
+		$this->beConstructedWith(file_get_contents('spec/mocks/with_nested_bullets.md'));
+
+		$this->getChanges()->shouldReturn([
+			'changed' => [
+				'I have nested bullet points<ul><li>nested bullet point 1</li><li>nested bullet point 2</li></ul>'
+			]
+		]);
+	}
 }

--- a/spec/mocks/with_nested_bullets.md
+++ b/spec/mocks/with_nested_bullets.md
@@ -1,0 +1,4 @@
+### Changed
+- I have nested bullet points
+  - nested bullet point 1
+  - nested bullet point 2

--- a/src/Retrievers/ChangesRetriever.php
+++ b/src/Retrievers/ChangesRetriever.php
@@ -36,7 +36,7 @@ class ChangesRetriever extends AbstractRetriever
 			return [];
 		}
 
-		$lines = (new LineRetriever($node->nextAll()->first()->filter('li')))->retrieve();
+		$lines = (new LineRetriever($node->nextAll()->first()->children('li')))->retrieve();
 
 		return [
 			'section' => $key,


### PR DESCRIPTION
This fixes the case where nested bullet points (which give extra explanation about a changelog entry) are seen as different entries.

The added tests makes it pretty clear I guess.